### PR TITLE
repalce `createCanvasContext`(2.9.0 deprecated)

### DIFF
--- a/src/RenderTarget.js
+++ b/src/RenderTarget.js
@@ -33,7 +33,6 @@ class RenderTarget {
     //this.ctx = polyfillCanvasCtx(wx.createCanvasContext('writer-canvas', view));
     //this.canvas = this.view.selectComponent('#writer-canvas');
     
-    // repalce `createCanvasContext`(2.9.0 deprecated) with `createSelectorQuery`
     wx.createSelectorQuery()
       .in(view)
       .select('#writer-canvas')

--- a/src/RenderTarget.js
+++ b/src/RenderTarget.js
@@ -30,8 +30,23 @@ class RenderTarget {
   constructor(view) {
     this.view = view;
     this.eventEmitter = new EventEmitter();
-    this.ctx = polyfillCanvasCtx(wx.createCanvasContext('writer-canvas', view));
-    this.canvas = this.view.selectComponent('#writer-canvas');
+    //this.ctx = polyfillCanvasCtx(wx.createCanvasContext('writer-canvas', view));
+    //this.canvas = this.view.selectComponent('#writer-canvas');
+    
+    // repalce `createCanvasContext`(2.9.0 deprecated) with `createSelectorQuery`
+    wx.createSelectorQuery()
+      .in(view)
+      .select('#writer-canvas')
+      .fields({ node: true, size: true })
+	    .exec((res) => {
+            let info = res[0];
+            const dpr = wx.getSystemInfoSync().pixelRatio;
+            this.canvas = info.node;
+            this.canvas.width = info.width * dpr;
+            this.canvas.height = info.height * dpr;
+            this.ctx = this.canvas.getContext('2d');
+            this.ctx.scale(dpr, dpr);
+      });
   }
 
   addPointerStartListener(callback) {

--- a/src/RenderTarget.js
+++ b/src/RenderTarget.js
@@ -30,8 +30,6 @@ class RenderTarget {
   constructor(view) {
     this.view = view;
     this.eventEmitter = new EventEmitter();
-    //this.ctx = polyfillCanvasCtx(wx.createCanvasContext('writer-canvas', view));
-    //this.canvas = this.view.selectComponent('#writer-canvas');
     
     wx.createSelectorQuery()
       .in(view)


### PR DESCRIPTION
repalce `createCanvasContext`(2.9.0 deprecated) with `createSelectorQuery`
fix Issues [35](https://github.com/chanind/hanzi-writer-miniprogram/issues/35) [36](https://github.com/chanind/hanzi-writer-miniprogram/issues/36) [51](https://github.com/chanind/hanzi-writer-miniprogram/issues/51) [52](https://github.com/chanind/hanzi-writer-miniprogram/issues/52)